### PR TITLE
Update 2016-12-06-typescript-generic.md

### DIFF
--- a/_posts/2016-12-06-typescript-generic.md
+++ b/_posts/2016-12-06-typescript-generic.md
@@ -54,7 +54,7 @@ class NumberQueue extends Queue {
     super.push(item);
   }
   pop(): number {
-    return this.pop();
+    return super.shift(); // or this.data.shift();
   }
 }
 


### PR DESCRIPTION
우분투 16.04 LTS 터미널 환경에서 실행 했을 때
this.pop() >> 오류 발생했습니다. 
오류 내용: RangeError: Maximum call stack size exceeded
항상 잘 보고 있습니다. 감사합니다
