### PR TITLE
fix: 예제에서 mixed content로 인한 get 실패 수정

### DIFF
--- a/_posts/2016-01-09-html5-tag-forms.md
+++ b/_posts/2016-01-09-html5-tag-forms.md
@@ -33,14 +33,14 @@ GET과 POST는 HTTP 프로토콜을 이용해서 사용자 입력 데이터를 �
 
 GET
 : - GET 방식은 전송 URL에 입력 데이터를 쿼리스트링으로 보내는 방식이다.
-<br> 예) http://jsonplaceholder.typicode.com/posts?userId=1&id=1
+<br> 예) https://jsonplaceholder.typicode.com/posts?userId=1&id=1
 - 전송 URL 바로 뒤에 '?'를 통해 데이터의 시작을 알려주고, key-value형태의 데이터를 추가한다. 1개 이상의 전송 데이터는 '&'로 구분한다.
 - URL에 전송 데이터가 모두 노출되기 때문에 보안에 문제가 있으며 전송할 수 있는 데이터의 한계가 있다. (최대 255자).
 - [REST API](./js-rest-api)에서 GET 메소드는 모든 또는 특정 리소스의 조회를 요청한다.
 
 POST
 : - POST 방식은 Request Body에 담아 보내는 방식이다.
-<br> 예) http://jsonplaceholder.typicode.com/posts
+<br> 예) https://jsonplaceholder.typicode.com/posts
 - URL에 전송 데이터가 모두 노출되지 않지만 GET에 비해 속도가 느리다.
 - [REST API](./js-rest-api)에서 POST 메소드는 특정 리소스의 생성을 요청한다.
 
@@ -53,7 +53,7 @@ POST
 <!DOCTYPE html>
 <html>
   <body>
-    <form action="http://jsonplaceholder.typicode.com/users" method="get">
+    <form action="https://jsonplaceholder.typicode.com/users" method="get">
       ID: <input type="text" name="id" value="1"><br>
       username: <input type="text" name="username" value="Bret"><br>
       <input type="submit" value="Submit">


### PR DESCRIPTION
배포된 버전에서 [html5-tag-forms](https://poiemaweb.com/html5-tag-forms)에 있는 jsonplaceholder.typicode.com로의 요청이 Mixed Content로 인하여 막히는 것을 확인하여 http에서 https로 경로를 수정했습니다.
추가로 `GET`과 `POST`에서의 url도 https로 변경하였습니다.

<img width="1822" height="1186" alt="스크린샷 2025-08-26 오후 1 50 36" src="https://github.com/user-attachments/assets/36fd155b-d9fa-4cb4-bd8a-a61fb5f3e876" />
